### PR TITLE
Fix/command array arguent type error

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,3 @@
+@echo off
+
+ant -f build/build.xml jar

--- a/build/build.properties
+++ b/build/build.properties
@@ -16,10 +16,10 @@ kspsyntaxparser.final-name = KSPSyntaxParser
 #-----------------------------------------------------------------------------
 
 # javac タスクの 'source' オプション
-kspsyntaxparser.javac.source-option = 1.6
+kspsyntaxparser.javac.source-option = 1.8
 
 # javac タスクの 'target' オプション
-kspsyntaxparser.javac.target-option = 1.6
+kspsyntaxparser.javac.target-option = 1.8
 
 # javac タスクの 'debug' オプション
 kspsyntaxparser.javac.debug-option = on

--- a/clean.bat
+++ b/clean.bat
@@ -1,0 +1,3 @@
+@echo off
+
+ant -f build/build.xml clean

--- a/data/symbols/commands.txt
+++ b/data/symbols/commands.txt
@@ -80,10 +80,10 @@ V	set_event_par_arr	*	@I	@I	@I	@I
 #-------------------------------------------------------------------------------------------------------
 # Array Commands
 #-------------------------------------------------------------------------------------------------------
-B	array_equal	*	I[]	I[]
-I||S	num_elements	*	I[]||R[]||S[]
-I||S	search	*	I[]	@I
-V	sort	*	I[]||R[]	@I
+B	array_equal	*	@I[]	@I[]
+I||S	num_elements	*	@I[]||@R[]||@S[]
+I||S	search	*	@I[]	@I
+V	sort	*	@I[]||@R[]	@I
 #-------------------------------------------------------------------------------------------------------
 # Group Commands
 #-------------------------------------------------------------------------------------------------------
@@ -205,8 +205,8 @@ I||S	load_array_str	init||persistence_changed||pgs_changed||ui_control	I[]||S[]	
 S	_load_ir_sample	*	@S	@I	@I
 I||S	load_ir_sample	*	@S	@I	@I
 I||S	load_midi_file	*	@S
-I||S	save_array	persistence_changed||pgs_changed||ui_control	I[]||S[]	@I
-I||S	save_array_str	persistence_changed||pgs_changed||ui_control	I[]||S[]	@S||@I
+I||S	save_array	persistence_changed||pgs_changed||ui_control	@I[]||@S[]	@I
+I||S	save_array_str	persistence_changed||pgs_changed||ui_control	@I[]||@S[]	@S||@I
 I||S	save_midi_file	*	@S
 #-------------------------------------------------------------------------------------------------------
 # Music Information Retrieval
@@ -287,7 +287,7 @@ V	dont_use_machine_mode	*	@I
 # Creator Tools Since 6.0
 #-------------------------------------------------------------------------------------------------------
 V	watch_var	*	@I||@S||@R
-V	watch_array_idx	*	I[]||S[]||R[]	@I
+V	watch_array_idx	*	@I[]||@S[]||@R[]	@I
 V	disable_logging	*	@I
 #-------------------------------------------------------------------------------------------------------
 # Undocumented

--- a/jj.bat
+++ b/jj.bat
@@ -1,0 +1,3 @@
+@echo off
+
+ant -f build/build.xml javacc-jj

--- a/rebuild.bat
+++ b/rebuild.bat
@@ -1,0 +1,4 @@
+@echo off
+
+call clean.bat
+call build.bat

--- a/setenv.bat
+++ b/setenv.bat
@@ -1,0 +1,9 @@
+@echo off
+
+set JAVA_HOME=C:\Java\jdk8
+set ANT_HOME=C:\Java\ant
+set PATH=%JAVA_HOME%\bin;%ANT_HOME%\bin;%PATH%
+
+set ANT_OPTS=-Dfile.encoding=UTF-8
+
+chcp 65001

--- a/src/java/net/rkoubou/kspparser/analyzer/data/reserved/ReservedSymbolManager.java
+++ b/src/java/net/rkoubou/kspparser/analyzer/data/reserved/ReservedSymbolManager.java
@@ -370,7 +370,7 @@ public class ReservedSymbolManager implements KSPParserTreeConstants, AnalyzerCo
         {
             type = TYPE_INT | TYPE_STRING;
         }
-        else if( t == "I[]" )
+        else if( t == "I[]" || t == "@I[]" )
         {
             type = TYPE_INT | TYPE_ATTR_ARRAY;
         }
@@ -382,7 +382,7 @@ public class ReservedSymbolManager implements KSPParserTreeConstants, AnalyzerCo
         {
             type = TYPE_REAL | TYPE_STRING;
         }
-        else if( t == "R[]" )
+        else if( t == "R[]" || t == "@R[]" )
         {
             type = TYPE_REAL | TYPE_ATTR_ARRAY;
         }
@@ -390,7 +390,7 @@ public class ReservedSymbolManager implements KSPParserTreeConstants, AnalyzerCo
         {
             type = TYPE_STRING;
         }
-        else if( t == "S[]" )
+        else if( t == "S[]" || t == "@S[]" )
         {
             type = TYPE_STRING | TYPE_ATTR_ARRAY;
         }


### PR DESCRIPTION
## Bug fixes

いくつかのコマンドの引数でビルトイン変数や定数を指定した場合に型の不一致というエラーを検出する。
command.txt 内の型の記述で、非配列の型と同様に `@I[]` というように `@` を記述した場合に定数も受け付けるように対応した。

Detected an error of type mismatch when a built-in variable or constant is specified as an argument of some commands.
In the type description in command.txt, constants are now accepted when `@` is specified as `@I[]` as well as non-array types.

```
on init
    declare $num
    $num := num_elements( !NI_DND_ITEMS_ARRAY ) { error: num_elements : Argument(s) incompatible type }
end on
```

## Java version upgrade

1.6 to 1.8.

1.6はもう古すぎることや、環境を構築できないためバージョンを引き上げた。

The version 1.6 was raised because it was already too old and the environment could not be built.